### PR TITLE
Update configuration options for ports, icon, webui

### DIFF
--- a/rtsp-to-webrtc/config.yaml
+++ b/rtsp-to-webrtc/config.yaml
@@ -4,6 +4,12 @@ version: "0.0.3"
 slug: rtsp-to-webrtc
 description: RTSP Stream to WebBrowser over WebRTC based on Pion
 url: "https://github.com/allenporter/stream-addons/tree/main/rtsp-to-webrtc"
+panel_icon: mdi:webrtc
+webui: "http://[HOST]:[PORT:8083]"
+ports:
+  8083/tcp: 8083
+ports_description:
+  8083/tcp: "RTSPtoWebRTC server"
 arch:
   - armhf
   - armv7


### PR DESCRIPTION
Update `config.yaml` with additional fields from https://developers.home-assistant.io/docs/add-ons/configuration
Default ports come from examples in https://github.com/deepch/RTSPtoWebRTC