### PR TITLE
Disable host network

### DIFF
--- a/rtsp-to-web/config.yaml
+++ b/rtsp-to-web/config.yaml
@@ -5,8 +5,12 @@ slug: rtsp-to-web
 description: RTSP Stream to WebBrowser over WebRTC and other protocols based on Pion
 url: "https://github.com/allenporter/stream-addons/tree/main/rtsp-to-web"
 panel_icon: mdi:webrtc
-webui: "http://[HOST]:[PORT:8083]"
-host_network: true
+ports:
+  8083/tcp: null
+  5541/tcp: null
+ports_description:
+  8083/tcp: "RTSPtoWeb WebServer and API"
+  5541/tcp: "RTSPtoWeb RTSP"
 discovery: ["rtsp_to_webrtc"]
 watchdog: "http://[HOST]:[PORT:8083]/"
 arch:

--- a/rtsp-to-web/rootfs/app/config.json
+++ b/rtsp-to-web/rootfs/app/config.json
@@ -4,9 +4,9 @@
     "http_debug": false,
     "http_demo": true,
     "http_dir": "web",
-    "http_port": ":%%http_port%%",
+    "http_port": "0.0.0.0:%%http_port%%",
     "log_level": "%%log_level%%",
-    "rtsp_port": ":%%rtsp_port%%",
+    "rtsp_port": "0.0.0.0:%%rtsp_port%%",
     "https": false,
     "token": { }
   },

--- a/rtsp-to-web/rootfs/etc/services.d/rtsp-to-web/discovery
+++ b/rtsp-to-web/rootfs/etc/services.d/rtsp-to-web/discovery
@@ -7,10 +7,14 @@ declare http_port
 
 http_port=$(bashio::config 'http_port')
 
+# Wait for server to start before proceeding
+bashio::net.wait_for "${http_port}"
+
 # Create discovery config payload for Home Assistant
+
 config=$(bashio::var.json \
-    host 127.0.0.1 \
-    port $http_port \
+    host "$(bashio::addon.hostname)" \
+    port "${http_port}" \
 )
 
 # Send discovery info


### PR DESCRIPTION
This should increase the addon rating. Host network should not be needed if no dynamic ports or port ranges are used.

This also disables external port forwarding for the add-on. If it is meant to be accessed from the HA integration, it will not be required.

This supersedes #24