### PR TITLE
Optimize addon docker image

### DIFF
--- a/rtsp-to-web/Dockerfile
+++ b/rtsp-to-web/Dockerfile
@@ -3,45 +3,43 @@
 # Example build command from add-on root directory:
 # $ docker build --build-arg BUILD_FROM="homeassistant/amd64-base:latest" --build-arg "BUILD_ARCH=amd64" --build-arg TEMPIO_VERSION=2021.09.0 -t rtsp-to-web rtsp-to-web
 
-ARG BUILD_FROM
-
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
-FROM $BUILD_FROM
-ARG TEMPIO_VERSION=2021.09.0
-ARG BUILD_ARCH
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:11.0.1
 
-# Execute during the build of the image
+
+FROM golang:1.17.6-alpine3.15 AS build
+
+RUN apk add --no-cache git
+
+# Clone repo
+ARG REPO="deepch/RTSPtoWeb"
+WORKDIR /workspace
 RUN \
-    curl -sSLf -o /usr/bin/tempio \
-    "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}"
-
-
-RUN apk add go git
-
-ARG REPO=github.com/deepch/RTSPtoWeb
-WORKDIR /build/$REPO
-
-RUN git clone https://$REPO .
-RUN git fetch
-RUN git reset --hard "64289619ffa24d99ca3e0537fe37f2660cb79cf6"
+    git clone https://github.com/$REPO . \
+    && git reset --hard "64289619ffa24d99ca3e0537fe37f2660cb79cf6"
 
 # Apply local patches
 COPY *.patch .
-RUN for i in *.patch; do \
-    git apply "${i}"; done
+RUN git apply -- *.patch
 
-RUN go get
-RUN go mod download
-RUN CGO_ENABLED=0 go build -a -o /app/rtsp-to-web
-RUN cp -rp web /app
-RUN chmod +x /app/rtsp-to-web
-
-# Copy root filesystem
-COPY rootfs /
-
-WORKDIR /app
-
+# Build
 ENV GO111MODULE="on"
 ENV GIN_MODE="release"
+ENV CGO_ENABLED="0"
+RUN \
+    go get \
+    && go mod download \
+    && go build -a -o ./rtsp-to-web
 
-EXPOSE 8083
+
+FROM scratch AS rootfs
+
+COPY rootfs /
+COPY --from=build /workspace/web /app/web
+COPY --from=build /workspace/rtsp-to-web /app/rtsp-to-web
+
+
+FROM $BUILD_FROM
+
+# Copy root filesystem
+COPY --from=rootfs / /

--- a/rtsp-to-web/Dockerfile
+++ b/rtsp-to-web/Dockerfile
@@ -7,13 +7,15 @@
 ARG BUILD_ARCH="amd64"
 ARG BUILD_FROM="ghcr.io/hassio-addons/base/${BUILD_ARCH}:11.0.1"
 
-ARG GO111MODULE="on"
-ARG GIN_MODE="release"
+
+FROM ${BUILD_FROM} AS base
+
+ENV GIN_MODE="release"
 
 
-FROM ${BUILD_FROM} AS build
+FROM base AS build
 
-RUN apk add --no-cache go=~1.17.4-r0 git=~2.34.1-r0
+RUN apk add --no-cache git go=~1.17.4-r0
 
 # Clone repo
 ARG REPO="deepch/RTSPtoWeb"
@@ -27,9 +29,8 @@ COPY *.patch .
 RUN git apply -- *.patch
 
 # Build
-ARG GO111MODULE
-ARG GIN_MODE
-ARG CGO_ENABLED="0"
+ENV GO111MODULE="on"
+ENV CGO_ENABLED="0"
 RUN \
     go get \
     && go mod download \
@@ -43,12 +44,7 @@ COPY --from=build /workspace/web /app/web
 COPY --from=build /workspace/rtsp-to-web /app/rtsp-to-web
 
 
-FROM ${BUILD_FROM}
-
-ARG GO111MODULE
-ARG GIN_MODE
-ENV GO111MODULE="${GO111MODULE}"
-ENV GIN_MODE="${GIN_MODE}"
+FROM base
 
 # Copy root filesystem
 COPY --from=rootfs / /

--- a/rtsp-to-web/Dockerfile
+++ b/rtsp-to-web/Dockerfile
@@ -10,7 +10,7 @@ ARG BUILD_FROM="ghcr.io/home-assistant/${BUILD_ARCH}-base:latest"
 
 FROM ${BUILD_FROM} AS build
 
-RUN apk add --no-cache git go=~1.17.4-r0
+RUN apk add --no-cache git go
 
 # Clone repo
 ARG REPO="deepch/RTSPtoWeb"

--- a/rtsp-to-web/Dockerfile
+++ b/rtsp-to-web/Dockerfile
@@ -6,6 +6,9 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 ARG BUILD_ARCH=amd64
 
+ARG GO111MODULE="on"
+ARG GIN_MODE="release"
+
 
 FROM golang:1.17.6-alpine3.15 AS build
 
@@ -23,9 +26,9 @@ COPY *.patch .
 RUN git apply -- *.patch
 
 # Build
-ENV GO111MODULE="on"
-ENV GIN_MODE="release"
-ENV CGO_ENABLED="0"
+ARG GO111MODULE
+ARG GIN_MODE
+ARG CGO_ENABLED="0"
 RUN \
     go get \
     && go mod download \
@@ -40,6 +43,11 @@ COPY --from=build /workspace/rtsp-to-web /app/rtsp-to-web
 
 
 FROM ghcr.io/hassio-addons/base/${BUILD_ARCH}:11.0.1
+
+ARG GO111MODULE
+ARG GIN_MODE
+ENV GO111MODULE="${GO111MODULE}"
+ENV GIN_MODE="${GIN_MODE}"
 
 # Copy root filesystem
 COPY --from=rootfs / /

--- a/rtsp-to-web/Dockerfile
+++ b/rtsp-to-web/Dockerfile
@@ -5,7 +5,7 @@
 
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 ARG BUILD_ARCH="amd64"
-ARG BUILD_FROM="ghcr.io/hassio-addons/base/${BUILD_ARCH}:11.0.1"
+ARG BUILD_FROM="ghcr.io/home-assistant/${BUILD_ARCH}-base:latest"
 
 
 FROM ${BUILD_FROM} AS build

--- a/rtsp-to-web/Dockerfile
+++ b/rtsp-to-web/Dockerfile
@@ -11,9 +11,9 @@ ARG GO111MODULE="on"
 ARG GIN_MODE="release"
 
 
-FROM golang:1.17.6-alpine3.15 AS build
+FROM ${BUILD_FROM} AS build
 
-RUN apk add --no-cache git
+RUN apk add --no-cache go=~1.17.6-r0 git=~2.35.1-r0
 
 # Clone repo
 ARG REPO="deepch/RTSPtoWeb"

--- a/rtsp-to-web/Dockerfile
+++ b/rtsp-to-web/Dockerfile
@@ -4,7 +4,8 @@
 # $ docker build --tag rtsp-to-web rtsp-to-web
 
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
-ARG BUILD_ARCH=amd64
+ARG BUILD_ARCH="amd64"
+ARG BUILD_FROM="ghcr.io/hassio-addons/base/${BUILD_ARCH}:11.0.1"
 
 ARG GO111MODULE="on"
 ARG GIN_MODE="release"
@@ -42,7 +43,7 @@ COPY --from=build /workspace/web /app/web
 COPY --from=build /workspace/rtsp-to-web /app/rtsp-to-web
 
 
-FROM ghcr.io/hassio-addons/base/${BUILD_ARCH}:11.0.1
+FROM ${BUILD_FROM}
 
 ARG GO111MODULE
 ARG GIN_MODE

--- a/rtsp-to-web/Dockerfile
+++ b/rtsp-to-web/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 #
 # Example build command from add-on root directory:
-# $ docker build --build-arg BUILD_FROM="homeassistant/amd64-base:latest" --build-arg "BUILD_ARCH=amd64" --build-arg TEMPIO_VERSION=2021.09.0 -t rtsp-to-web rtsp-to-web
+# $ docker build --tag rtsp-to-web rtsp-to-web
 
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:11.0.1
+ARG BUILD_ARCH=amd64
 
 
 FROM golang:1.17.6-alpine3.15 AS build
@@ -39,7 +39,7 @@ COPY --from=build /workspace/web /app/web
 COPY --from=build /workspace/rtsp-to-web /app/rtsp-to-web
 
 
-FROM $BUILD_FROM
+FROM ghcr.io/hassio-addons/base/${BUILD_ARCH}:11.0.1
 
 # Copy root filesystem
 COPY --from=rootfs / /

--- a/rtsp-to-web/Dockerfile
+++ b/rtsp-to-web/Dockerfile
@@ -8,12 +8,7 @@ ARG BUILD_ARCH="amd64"
 ARG BUILD_FROM="ghcr.io/hassio-addons/base/${BUILD_ARCH}:11.0.1"
 
 
-FROM ${BUILD_FROM} AS base
-
-ENV GIN_MODE="release"
-
-
-FROM base AS build
+FROM ${BUILD_FROM} AS build
 
 RUN apk add --no-cache git go=~1.17.4-r0
 
@@ -44,7 +39,9 @@ COPY --from=build /workspace/web /app/web
 COPY --from=build /workspace/rtsp-to-web /app/rtsp-to-web
 
 
-FROM base
+FROM ${BUILD_FROM}
+
+ENV GIN_MODE="release"
 
 # Copy root filesystem
 COPY --from=rootfs / /

--- a/rtsp-to-web/Dockerfile
+++ b/rtsp-to-web/Dockerfile
@@ -13,7 +13,7 @@ ARG GIN_MODE="release"
 
 FROM ${BUILD_FROM} AS build
 
-RUN apk add --no-cache go=~1.17.6-r0 git=~2.35.1-r0
+RUN apk add --no-cache go=~1.17.4-r0 git=~2.34.1-r0
 
 # Clone repo
 ARG REPO="deepch/RTSPtoWeb"

--- a/rtsp-to-web/build.yaml
+++ b/rtsp-to-web/build.yaml
@@ -1,4 +1,11 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration/#add-on-extended-build
+build_from:
+  # https://github.com/hassio-addons/addon-base
+  aarch64: "ghcr.io/hassio-addons/base/amd64:11.0.1"
+  amd64: "ghcr.io/hassio-addons/base/amd64:11.0.1"
+  armhf: "ghcr.io/hassio-addons/base/armhf:11.0.1"
+  armv7: "ghcr.io/hassio-addons/base/armv7:11.0.1"
+  i386: "ghcr.io/hassio-addons/base/i386:11.0.1"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: RTSPtoWebRTC"
   org.opencontainers.image.description: "RTSP Stream to WebBrowser over WebRTC based on Pion."

--- a/rtsp-to-web/build.yaml
+++ b/rtsp-to-web/build.yaml
@@ -1,11 +1,4 @@
-# https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
-build_from:
-  # https://github.com/hassio-addons/addon-base
-  aarch64: "ghcr.io/hassio-addons/base/amd64:11.0.1"
-  amd64: "ghcr.io/hassio-addons/base/amd64:11.0.1"
-  armhf: "ghcr.io/hassio-addons/base/armhf:11.0.1"
-  armv7: "ghcr.io/hassio-addons/base/armv7:11.0.1"
-  i386: "ghcr.io/hassio-addons/base/i386:11.0.1"
+# https://developers.home-assistant.io/docs/add-ons/configuration/#add-on-extended-build
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: RTSPtoWebRTC"
   org.opencontainers.image.description: "RTSP Stream to WebBrowser over WebRTC based on Pion."

--- a/rtsp-to-web/build.yaml
+++ b/rtsp-to-web/build.yaml
@@ -1,11 +1,10 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration/#add-on-extended-build
 build_from:
-  # https://github.com/hassio-addons/addon-base
-  aarch64: "ghcr.io/hassio-addons/base/amd64:11.0.1"
-  amd64: "ghcr.io/hassio-addons/base/amd64:11.0.1"
-  armhf: "ghcr.io/hassio-addons/base/armhf:11.0.1"
-  armv7: "ghcr.io/hassio-addons/base/armv7:11.0.1"
-  i386: "ghcr.io/hassio-addons/base/i386:11.0.1"
+  aarch64: "ghcr.io/home-assistant/aarch64-base:3.14"
+  amd64: "ghcr.io/home-assistant/amd64-base:3.14"
+  armhf: "ghcr.io/home-assistant/armhf-base:3.14"
+  armv7: "ghcr.io/home-assistant/armv7-base:3.14"
+  i386: "ghcr.io/home-assistant/i386-base:3.14"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: RTSPtoWebRTC"
   org.opencontainers.image.description: "RTSP Stream to WebBrowser over WebRTC based on Pion."

--- a/rtsp-to-web/build.yaml
+++ b/rtsp-to-web/build.yaml
@@ -1,14 +1,13 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 build_from:
-  aarch64: "ghcr.io/home-assistant/aarch64-base:3.14"
-  amd64: "ghcr.io/home-assistant/amd64-base:3.14"
-  armhf: "ghcr.io/home-assistant/armhf-base:3.14"
-  armv7: "ghcr.io/home-assistant/armv7-base:3.14"
-  i386: "ghcr.io/home-assistant/i386-base:3.14"
+  # https://github.com/hassio-addons/addon-base
+  aarch64: "ghcr.io/hassio-addons/base/amd64:11.0.1"
+  amd64: "ghcr.io/hassio-addons/base/amd64:11.0.1"
+  armhf: "ghcr.io/hassio-addons/base/armhf:11.0.1"
+  armv7: "ghcr.io/hassio-addons/base/armv7:11.0.1"
+  i386: "ghcr.io/hassio-addons/base/i386:11.0.1"
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: RTSPtoWebRTC"
   org.opencontainers.image.description: "RTSP Stream to WebBrowser over WebRTC based on Pion."
   org.opencontainers.image.source: "https://github.com/allenporter/stream-addons"
   org.opencontainers.image.licenses: "Apache License 2.0"
-args:
-  TEMPIO_VERSION: "2021.05.0"

--- a/rtsp-to-web/rootfs/etc/services.d/rtsp-to-web/run
+++ b/rtsp-to-web/rootfs/etc/services.d/rtsp-to-web/run
@@ -7,6 +7,6 @@
 bashio::log.info "Starting discovery service"
 ./discovery &
 
-bashio::log.info "Starting RSTPtoWebRTC"
+bashio::log.info "Starting RSTPtoWeb"
 cd /app
-exec /app/rtsp-to-web
+exec ./rtsp-to-web


### PR DESCRIPTION
Comparison (before and after):

```console
❯ docker images
REPOSITORY                              TAG       IMAGE ID       CREATED          SIZE
ghcr.io/allenporter/amd64-rtsp-to-web   latest    83ebfeef827a   11 days ago      954MB
ghcr.io/felipecrs/amd64-rtsp-to-web     latest    1253f6cf9ad8   13 minutes ago   60.3MB
```

Which means that the addon is much quicker to install now, and takes less space.
