### PR TITLE
Release rtsp-to-web 1.2.0

### DIFF
--- a/rtsp-to-web/CHANGELOG.md
+++ b/rtsp-to-web/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 1.2.0
+
+- Update to [RTSPtoWeb 2.1.0](https://github.com/deepch/RTSPtoWeb/releases/tag/v2.1.0) with audio stuttering improvements, crash fixes, and Web UI improvements
+
 ## 1.1.0
 
 - Update to RTSPtoWeb 1.0.0 with bug fixes

--- a/rtsp-to-web/build.yaml
+++ b/rtsp-to-web/build.yaml
@@ -6,7 +6,7 @@ build_from:
   armv7: "ghcr.io/home-assistant/armv7-base:3.14"
   i386: "ghcr.io/home-assistant/i386-base:3.14"
 args:
-  RTSPTOWEB_VERSION: v1.0.0
+  RTSPTOWEB_VERSION: v2.1.0
   RTSPTOWEB_REPO: deepch/RTSPtoWeb
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: RTSPtoWebRTC"

--- a/rtsp-to-web/config.yaml
+++ b/rtsp-to-web/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: RTSPtoWeb - WebRTC
-version: "1.1.0"
+version: "1.2.0"
 slug: rtsp-to-web
 description: RTSP Stream to WebBrowser over WebRTC and other protocols based on Pion
 url: "https://github.com/allenporter/stream-addons/tree/main/rtsp-to-web"


### PR DESCRIPTION
Release rtsp-to-web 1.2.0 

### Updates

- Update to [RTSPtoWeb 2.1.0](https://github.com/deepch/RTSPtoWeb/releases/tag/v2.1.0) with audio stuttering improvements, crash fixes, and Web UI improvements