### PR TITLE
Upgrade s6 overlay to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _RTSP Stream to Web server that supports WebRTC, and more protocols. This server
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [i386-shield]: https://img.shields.io/badge/i386-yes-green.sv
 
-### [RTSPToWebRTCP add-on](./rtsp-to-webrtc)
+### [RTSPToWebRTC add-on](./rtsp-to-webrtc)
 
 _RTSP Stream to WebBrowser over WebRTC based on Pion. This is a Home Assistant Add-on packaging the project https://github.com/deepch/RTSPtoWebRTC -- however, users should prefer to install RTSPtoWeb instead which supports WebRTC and many more protocols and is better supported._
 

--- a/rtsp-to-web/CHANGELOG.md
+++ b/rtsp-to-web/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 1.4.0
+
+- Update s6 overlay to v3
+
 ## 1.3.0
 
 - Update to [RTSPtoWeb 2.4.0](https://github.com/deepch/RTSPtoWeb/releases/tag/2.4.0)

--- a/rtsp-to-web/build.yaml
+++ b/rtsp-to-web/build.yaml
@@ -1,10 +1,10 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration/#add-on-extended-build
 build_from:
-  aarch64: "ghcr.io/home-assistant/aarch64-base:3.14"
-  amd64: "ghcr.io/home-assistant/amd64-base:3.14"
-  armhf: "ghcr.io/home-assistant/armhf-base:3.14"
-  armv7: "ghcr.io/home-assistant/armv7-base:3.14"
-  i386: "ghcr.io/home-assistant/i386-base:3.14"
+  aarch64: "ghcr.io/home-assistant/aarch64-base:3.15"
+  amd64: "ghcr.io/home-assistant/amd64-base:3.15"
+  armhf: "ghcr.io/home-assistant/armhf-base:3.15"
+  armv7: "ghcr.io/home-assistant/armv7-base:3.15"
+  i386: "ghcr.io/home-assistant/i386-base:3.15"
 args:
   # renovate: datasource=github-releases depName=deepch/RTSPtoWeb
   RTSPTOWEB_VERSION: v2.4.0

--- a/rtsp-to-web/config.yaml
+++ b/rtsp-to-web/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: RTSPtoWeb - WebRTC
-version: "1.3.0"
+version: "1.4.0"
 slug: rtsp-to-web
 description: RTSP Stream to WebBrowser over WebRTC and other protocols based on Pion
 url: "https://github.com/allenporter/stream-addons/tree/main/rtsp-to-web"

--- a/rtsp-to-web/rootfs/etc/services.d/rtsp-to-web/finish
+++ b/rtsp-to-web/rootfs/etc/services.d/rtsp-to-web/finish
@@ -1,9 +1,13 @@
-#!/usr/bin/execlineb -S1
+#!/usr/bin/env bashio
 # ==============================================================================
-# Take down the S6 supervision tree when server fails
+# Take down the S6 supervision tree when example fails
 # s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if { s6-test ${1} -ne 0 }
-if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+declare APP_EXIT_CODE=${1}
+
+if [[ "${APP_EXIT_CODE}" -ne 0 ]] && [[ "${APP_EXIT_CODE}" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on with exit code ${APP_EXIT_CODE}"
+  echo "${APP_EXIT_CODE}" > /run/s6-linux-init-container-results/exitcode
+  exec /run/s6/basedir/bin/halt
+fi


### PR DESCRIPTION
Upgrade s6 overlay to v3 following https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/

Issue #81